### PR TITLE
fixed bug, that merged cells were not parsed

### DIFF
--- a/lib/src/parser/parse.dart
+++ b/lib/src/parser/parse.dart
@@ -174,10 +174,11 @@ class Parser {
     Map spannedCells = <String, List<String>>{};
     _excel._sheets.forEach((sheetName, node) {
       _excel._availSheet(sheetName);
-      XmlElement elementNode = node as XmlElement;
+      XmlElement sheetDataNode = node as XmlElement;
       List spanList = <String>[];
 
-      elementNode.findAllElements('mergeCell').forEach((elemen) {
+      final worksheetNode = sheetDataNode.parent;
+      worksheetNode!.findAllElements('mergeCell').forEach((elemen) {
         String? ref = elemen.getAttribute('ref');
         if (ref != null && ref.contains(':') && ref.split(':').length == 2) {
           if (!_excel._sheetMap[sheetName]!._spannedItems.contains(ref)) {
@@ -202,19 +203,6 @@ class Parser {
           _excel._mergeChangeLookup = sheetName;
         }
       });
-    });
-
-    // Remove those cells which are present inside the
-    _excel._sheetMap.forEach((sheetName, sheetObject) {
-      if (spannedCells.containsKey(sheetName)) {
-        sheetObject._sheetData.forEach((row, colMap) {
-          colMap.forEach((col, dataObject) {
-            if (!(spannedCells[sheetName].contains(getCellId(col, row)))) {
-              _excel[sheetName]._sheetData[row]?.remove(col);
-            }
-          });
-        });
-      }
     });
   }
 


### PR DESCRIPTION
`elementNode` was the `sheetdata` node and was searched for the `mergeCell` node which is incorrect, because the `mergeCell` node is not contained in `sheetData` node but instead in the parent node called `worksheet`. This is why merged cells were not parsed at all.

The comment "// Remove those cells which are present inside the" is not complete and the codeblock below it was never really executed, because the `spannedCells` was empty because of the bug. Now that it is not empty anymore because the correct node is searched for merged cells, the loop throws an error. While the columns are iterated, the code tries to delete entries, which can not happen while iterating. When changing to coe to not use an iterate to loop, it works that the cells are deleted. however this code deletes just every cell, that is not a combined cell, which makes a woorksheet empty, except for the combined cells.

However it is not even neccecary to remove any cells. That is why the codeblock is deleted. Parsing merged cells works afterwards just fine.